### PR TITLE
Adding distribution architecture to artifact id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -883,7 +883,7 @@
 									<repositoryId>${repository.id}</repositoryId>
 									<url>${repository.url}</url>
 									<groupId>com.enactor.chromium</groupId>
-									<artifactId>mac-binaries</artifactId>
+									<artifactId>mac-binaries-${distribution.arch}</artifactId>
 									<version>${project.version}</version>
 									<packaging>zip</packaging>
 								</configuration>
@@ -1054,7 +1054,7 @@
                                     <repositoryId>${repository.id}</repositoryId>
                                     <url>${repository.url}</url>
                                     <groupId>com.enactor.chromium</groupId>
-                                    <artifactId>mac-binaries</artifactId>
+                                    <artifactId>mac-binaries-${distribution.arch}</artifactId>
                                     <version>${project.version}</version>
                                     <packaging>zip</packaging>
                                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -883,8 +883,9 @@
 									<repositoryId>${repository.id}</repositoryId>
 									<url>${repository.url}</url>
 									<groupId>com.enactor.chromium</groupId>
-									<artifactId>mac-binaries-${distribution.arch}</artifactId>
+									<artifactId>mac-binaries</artifactId>
 									<version>${project.version}</version>
+									<classifier>${distribution.arch}</classifier>
 									<packaging>zip</packaging>
 								</configuration>
 							</execution>
@@ -1054,8 +1055,9 @@
                                     <repositoryId>${repository.id}</repositoryId>
                                     <url>${repository.url}</url>
                                     <groupId>com.enactor.chromium</groupId>
-                                    <artifactId>mac-binaries-${distribution.arch}</artifactId>
+                                    <artifactId>mac-binaries</artifactId>
                                     <version>${project.version}</version>
+									<classifier>${distribution.arch}</classifier>
                                     <packaging>zip</packaging>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Adding distribution architecture to artifact id to separate two architectures without overriding teh same pom.xml