### PR TITLE
build: do not fail the build when the clang-format download fails (macOS / py3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,12 @@ execute_process(
   RESULT_VARIABLE EXECUTE_RV
   )
 if(NOT EXECUTE_RV STREQUAL "0")
-  message(FATAL_ERROR "Execution failed with unexpected result: ${EXECUTE_RV}")
+  # clang-format is a code-FORMATTING tool, not required to compile jcef. Its
+  # download goes through the vendored gsutil (Python 2 only), which fails on a
+  # host without python2 — e.g. macOS, where Apple removed python2 and the build
+  # runs cmake under python3. Don't fail the whole build over an optional tool:
+  # warn and continue. (EDIAPT-1706 — macOS CEF build on jenkins1.)
+  message(WARNING "clang-format download failed (result ${EXECUTE_RV}); continuing without it (formatting-only tool, not required to build).")
 endif()
 
 


### PR DESCRIPTION
## Problem

On macOS the cmake configure step aborts the whole build:

```
Downloading clang-format from Google Storage...
ModuleNotFoundError: No module named 'six.moves'        # vendored gsutil 4.68 is Python-2 only
CMake Error at CMakeLists.txt:309: Execution failed with unexpected result: 1
```

`tools/buildtools/download_from_google_storage.py` runs the bundled **gsutil 4.68**, which is Python-2-only (its vendored `six` breaks under python3). Windows/Linux configure under Python 2.7 so it works there, but **macOS has no python2** (Apple removed it; Homebrew dropped `python@2`), so the build runs cmake under python3 and this download fails — taking the entire build down with it.

clang-format is a code-**formatting** tool; it is not an input to compiling jcef. Failing the build over it is too strict.

## Change

Make the clang-format download non-fatal: `FATAL_ERROR` → `WARNING`. The build continues without clang-format on hosts that can't run the py2 gsutil. Windows/Linux are unaffected (the download still succeeds there under py2.7); only the failure *handling* changes.

## Context

Unblocks the macOS CEF build on the new jenkins1 macOS agents (Jira EDIAPT-1706). With this, the arm64 configure completes (JDK + Python + JNI all resolve) and the build proceeds to the native compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)