### PR TITLE
make_docs.sh: only pass --ignore-source-errors when javadoc supports it

### DIFF
--- a/tools/make_docs.sh
+++ b/tools/make_docs.sh
@@ -6,5 +6,16 @@
 DIR="$( cd "$( dirname "$0" )" && cd .. && pwd )"
 OUT_PATH="${DIR}/out/docs"
 
-javadoc --ignore-source-errors -Xdoclint:none -windowtitle "CEF3 Java API Docs" -footer "<center><a href="https://github.com/chromiumembedded/java-cef" target="_top">Chromium Embedded Framework (CEF)</a> Copyright &copy 2013 Marshall A. Greenblatt</center>" -nodeprecated -d "$OUT_PATH" -sourcepath "${DIR}/java" -link http://docs.oracle.com/javase/7/docs/api/ -subpackages org.cef
+# --ignore-source-errors is a JDK 9+ javadoc option. Building on JDK 8 (e.g. the
+# macOS JCEF build, which links the native lib against a JDK 8 JRE) makes javadoc
+# reject it as an invalid flag and abort, so out/docs is never produced. Pass the
+# flag only when the local javadoc advertises it: JDK 9+ keeps the source-error
+# tolerance, JDK 8 still generates docs (javadoc 8 is lenient about source errors
+# anyway).
+IGNORE_SOURCE_ERRORS=""
+if javadoc --help 2>&1 | grep -q -- '--ignore-source-errors'; then
+  IGNORE_SOURCE_ERRORS="--ignore-source-errors"
+fi
+
+javadoc $IGNORE_SOURCE_ERRORS -Xdoclint:none -windowtitle "CEF3 Java API Docs" -footer "<center><a href="https://github.com/chromiumembedded/java-cef" target="_top">Chromium Embedded Framework (CEF)</a> Copyright &copy 2013 Marshall A. Greenblatt</center>" -nodeprecated -d "$OUT_PATH" -sourcepath "${DIR}/java" -link http://docs.oracle.com/javase/7/docs/api/ -subpackages org.cef
 


### PR DESCRIPTION
`--ignore-source-errors` is a JDK 9+ javadoc option. Building JCEF on **JDK 8** (the macOS build links the native lib against a JDK 8 JRE) makes javadoc reject it as an invalid flag and abort — so `out/docs` is never generated and `make_distrib.sh`'s doc-copy step fails (observed in our macOS CI: javadoc usage dump + `cp: out/docs: No such file or directory`).

Detect support via `javadoc --help` and pass the flag only when present: JDK 9+ keeps the source-error tolerance, JDK 8 still generates docs (javadoc 8 is lenient about source errors). No behaviour change on JDK 9+.