### PR TITLE
make_readme.py: pass str (not bytes) to write_file — fix py3 TypeError

### DIFF
--- a/tools/make_readme.py
+++ b/tools/make_readme.py
@@ -67,7 +67,7 @@ def create_readme():
 
   data = data.replace('$PLATFORM$', platform_str)
 
-  write_file(os.path.join(output_dir, 'README.txt'), data.encode('utf-8'))
+  write_file(os.path.join(output_dir, 'README.txt'), data)
   if not options.quiet:
     sys.stdout.write('Creating README.TXT file.\n')
 


### PR DESCRIPTION
`write_file()` is version-aware: on py2 it does `data.decode('utf-8')` (expects bytes), on py3 it writes `data` directly to a text-mode utf-8 file (expects str). `make_readme.py` was the **only** caller pre-encoding to bytes (`data.encode('utf-8')`), so under python3 `write_file` hit `f.write(data)` with bytes:

```
TypeError: write() argument must be str, not bytes
```

This aborts README.txt generation whenever the build runs under python3 — e.g. the **macOS** JCEF build (`python` is python3; Apple ships no python2). Pass `data` (str) directly, matching `make_version_header.py`'s `write_file` call. Works under both py2 (`str.decode` → unicode) and py3; no other caller affected.